### PR TITLE
Dynamic pool implementation and process separation per worker id

### DIFF
--- a/client/app/Client.hs
+++ b/client/app/Client.hs
@@ -61,6 +61,7 @@ main = do
   let (workerArgs, ghcArgs) = splitArgs args
       mConf = getWorkerConfig workerArgs
   hPutStrLn stderr (show mConf)
+  hPutStrLn stderr (show args)
   hFlush stderr
   case mConf of
     Nothing -> do

--- a/comm/src/Message.hs
+++ b/comm/src/Message.hs
@@ -8,6 +8,7 @@ module Message
     wrapMsg,
     unwrapMsg,
     --
+    Id (..),
     Request (..),
     Response (..),
   ) where
@@ -76,8 +77,12 @@ wrapMsg x =
 unwrapMsg :: (Binary a) => Msg -> a
 unwrapMsg (Msg _n bs) = decode (L.fromStrict bs)
 
+newtype Id = Id String
+  deriving (Show, Binary)
+
 data Request = Request
-  { requestEnv :: [(String, String)],
+  { requestWorkerId :: Id,
+    requestEnv :: [(String, String)],
     requestArgs :: [String]
   }
   deriving (Show, Generic)

--- a/comm/src/Message.hs
+++ b/comm/src/Message.hs
@@ -82,6 +82,7 @@ newtype Id = Id String
 
 data Request = Request
   { requestWorkerId :: Maybe Id,
+    requestWorkerClose :: Bool,
     requestEnv :: [(String, String)],
     requestArgs :: [String]
   }
@@ -97,10 +98,3 @@ data Response = Response
   deriving (Show, Generic)
 
 instance Binary Response
-
-{-
-newtype ConsoleOutput = ConsoleOutput
-  { unConsoleOutput :: [String]
-  }
-  deriving Binary
--}

--- a/comm/src/Message.hs
+++ b/comm/src/Message.hs
@@ -78,7 +78,7 @@ unwrapMsg :: (Binary a) => Msg -> a
 unwrapMsg (Msg _n bs) = decode (L.fromStrict bs)
 
 newtype Id = Id String
-  deriving (Show, Binary)
+  deriving (Show, Eq, Binary)
 
 data Request = Request
   { requestWorkerId :: Id,

--- a/comm/src/Message.hs
+++ b/comm/src/Message.hs
@@ -81,7 +81,7 @@ newtype Id = Id String
   deriving (Show, Eq, Binary)
 
 data Request = Request
-  { requestWorkerId :: Id,
+  { requestWorkerId :: Maybe Id,
     requestEnv :: [(String, String)],
     requestArgs :: [String]
   }

--- a/plugin/src/GHCPersistentWorkerPlugin.hs
+++ b/plugin/src/GHCPersistentWorkerPlugin.hs
@@ -66,6 +66,7 @@ workerMain flags = do
     liftIO $ do
       mapM_ (\_ -> hPutStrLn stderr "=================================") [1..5]
       time <- getCurrentTime
+      hPutStrLn stderr $ "worker: " ++ (show n)
       hPutStrLn stderr (show time)
       mapM_ (\_ -> hPutStrLn stderr "=================================") [1..5]
     --
@@ -74,6 +75,7 @@ workerMain flags = do
     liftIO $ do
       mapM_ (\_ -> hPutStrLn stderr "|||||||||||||||||||||||||||||||||") [1..5]
       time <- getCurrentTime
+      hPutStrLn stderr $ "worker: " ++ (show n)
       hPutStrLn stderr (show time)
       mapM_ (\_ -> hPutStrLn stderr "|||||||||||||||||||||||||||||||||") [1..5]
     --

--- a/server/app/Pool.hs
+++ b/server/app/Pool.hs
@@ -15,7 +15,7 @@ import Data.IntMap (IntMap)
 import qualified Data.IntMap as IM
 import qualified Data.List as List
 import Message (Id)
-import System.IO (Handle, hFlush, hPrint, stdout)
+import System.IO (Handle, hFlush, hPrint, hPutStrLn, stdout)
 
 data HandleSet = HandleSet
   { handleArgIn :: Handle,
@@ -32,6 +32,7 @@ data Pool = Pool
 dumpStatus :: TVar Pool -> IO ()
 dumpStatus ref = do
   pool <- atomically (readTVar ref)
+  hPutStrLn stdout $ "poolLimit = " ++ show (poolLimit pool)
   mapM_ (hPrint stdout) $ IM.toAscList (poolStatus pool)
   hFlush stdout
 

--- a/server/app/Pool.hs
+++ b/server/app/Pool.hs
@@ -21,24 +21,33 @@ data HandleSet = HandleSet
   }
 
 data Pool = Pool
-  { poolStatus :: IntMap (Maybe Id),
+  { poolStatus :: IntMap (Bool, Maybe Id),
     poolHandles :: [(Int, HandleSet)]
   }
 
 dumpStatus :: TVar Pool -> IO ()
 dumpStatus ref = do
   pool <- atomically (readTVar ref)
-  print $ poolStatus pool
+  mapM_ print $ IM.toAscList (poolStatus pool)
+
+getAssignableWorker :: IntMap (Bool, Maybe Id) -> Id -> Maybe (Int, (Bool, Maybe Id))
+getAssignableWorker workers id' = List.find (isAssignable . snd) . IM.toAscList $ workers
+  where
+    isAssignable (b, mid)
+      | not b = case mid of
+                  Nothing -> True
+                  Just id'' -> id' == id''
+      | otherwise = False
 
 assignJob :: TVar Pool -> Id -> STM (Int, HandleSet)
 assignJob ref id' = do
   pool <- readTVar ref
   let workers = poolStatus pool
-  let m = List.find ((== Nothing) . snd) (IM.toAscList workers)
+  let m = getAssignableWorker workers id'
   case m of
     Nothing -> retry
     Just (i, _) -> do
-      let !workers' = IM.update (\_ -> Just (Just id')) i workers
+      let !workers' = IM.update (\_ -> Just (True, Just id')) i workers
           Just hset = List.lookup i (poolHandles pool)
       writeTVar ref (pool {poolStatus = workers'})
       pure (i, hset)
@@ -47,6 +56,5 @@ finishJob :: TVar Pool -> Int -> STM ()
 finishJob ref i = do
   pool <- readTVar ref
   let workers = poolStatus pool
-      !workers' = IM.update (\_ -> Just Nothing) i workers
+      !workers' = IM.update (\(_, m)  -> Just (False, m)) i workers
   writeTVar ref (pool {poolStatus = workers'})
-

--- a/server/app/Pool.hs
+++ b/server/app/Pool.hs
@@ -24,6 +24,7 @@ data HandleSet = HandleSet
 
 data Pool = Pool
   { poolLimit :: Int,
+    poolNext :: Int,
     poolStatus :: IntMap (Bool, Maybe Id),
     poolHandles :: [(Int, HandleSet)]
   }
@@ -44,7 +45,11 @@ getAssignableWorker workers mid' = List.find (isAssignable . snd) . IM.toAscList
                   (Just id'', Just id') -> id' == id''
       | otherwise = False
 
-assignJob :: TVar Pool -> Maybe Id -> STM (Either Int (Int, HandleSet))
+assignJob ::
+  TVar Pool ->
+  Maybe Id ->
+  -- | Right assigned, Left new id that will be used for new spawned worker process.
+  STM (Either Int (Int, HandleSet))
 assignJob ref mid' = do
   pool <- readTVar ref
   let workers = poolStatus pool

--- a/server/app/Pool.hs
+++ b/server/app/Pool.hs
@@ -16,9 +16,11 @@ import qualified Data.IntMap as IM
 import qualified Data.List as List
 import Message (Id)
 import System.IO (Handle, hFlush, hPrint, hPutStrLn, stdout)
+import System.Process (ProcessHandle)
 
 data HandleSet = HandleSet
-  { handleArgIn :: Handle,
+  { handleProcess :: ProcessHandle,
+    handleArgIn :: Handle,
     handleMsgOut :: Handle
   }
 

--- a/server/app/Pool.hs
+++ b/server/app/Pool.hs
@@ -13,7 +13,7 @@ import Data.IntMap (IntMap)
 import qualified Data.IntMap as IM
 import qualified Data.List as List
 import Message (Id)
-import System.IO (Handle)
+import System.IO (Handle, hFlush, hPrint, stdout)
 
 data HandleSet = HandleSet
   { handleArgIn :: Handle,
@@ -28,7 +28,8 @@ data Pool = Pool
 dumpStatus :: TVar Pool -> IO ()
 dumpStatus ref = do
   pool <- atomically (readTVar ref)
-  mapM_ print $ IM.toAscList (poolStatus pool)
+  mapM_ (hPrint stdout) $ IM.toAscList (poolStatus pool)
+  hFlush stdout
 
 getAssignableWorker :: IntMap (Bool, Maybe Id) -> Maybe Id -> Maybe (Int, (Bool, Maybe Id))
 getAssignableWorker workers mid' = List.find (isAssignable . snd) . IM.toAscList $ workers

--- a/server/app/Pool.hs
+++ b/server/app/Pool.hs
@@ -6,6 +6,7 @@ module Pool
   dumpStatus,
   assignJob,
   finishJob,
+  removeWorker,
 ) where
 
 import Control.Concurrent.STM (STM, TVar, atomically, readTVar, retry, writeTVar)
@@ -61,4 +62,14 @@ finishJob ref i = do
   pool <- readTVar ref
   let workers = poolStatus pool
       !workers' = IM.update (\(_, m)  -> Just (False, m)) i workers
+  writeTVar ref (pool {poolStatus = workers'})
+
+removeWorker :: TVar Pool -> Id -> STM ()
+removeWorker ref id' = do
+  pool <- readTVar ref
+  let workers = poolStatus pool
+      upd (b, m)
+        | m == Just id' = (False, Nothing)
+        | otherwise = (b, m)
+      !workers' = fmap upd workers
   writeTVar ref (pool {poolStatus = workers'})

--- a/server/app/Pool.hs
+++ b/server/app/Pool.hs
@@ -1,0 +1,52 @@
+{-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
+
+module Pool
+( HandleSet (..),
+  Pool (..),
+  dumpStatus,
+  assignJob,
+  finishJob,
+) where
+
+import Control.Concurrent.STM (STM, TVar, atomically, readTVar, retry, writeTVar)
+import Data.IntMap (IntMap)
+import qualified Data.IntMap as IM
+import qualified Data.List as List
+import Message (Id)
+import System.IO (Handle)
+
+data HandleSet = HandleSet
+  { handleArgIn :: Handle,
+    handleMsgOut :: Handle
+  }
+
+data Pool = Pool
+  { poolStatus :: IntMap (Maybe Id),
+    poolHandles :: [(Int, HandleSet)]
+  }
+
+dumpStatus :: TVar Pool -> IO ()
+dumpStatus ref = do
+  pool <- atomically (readTVar ref)
+  print $ poolStatus pool
+
+assignJob :: TVar Pool -> Id -> STM (Int, HandleSet)
+assignJob ref id' = do
+  pool <- readTVar ref
+  let workers = poolStatus pool
+  let m = List.find ((== Nothing) . snd) (IM.toAscList workers)
+  case m of
+    Nothing -> retry
+    Just (i, _) -> do
+      let !workers' = IM.update (\_ -> Just (Just id')) i workers
+          Just hset = List.lookup i (poolHandles pool)
+      writeTVar ref (pool {poolStatus = workers'})
+      pure (i, hset)
+
+finishJob :: TVar Pool -> Int -> STM ()
+finishJob ref i = do
+  pool <- readTVar ref
+  let workers = poolStatus pool
+      !workers' = IM.update (\_ -> Just Nothing) i workers
+  writeTVar ref (pool {poolStatus = workers'})
+

--- a/server/app/Server.hs
+++ b/server/app/Server.hs
@@ -136,7 +136,7 @@ main = do
       workers = [1..n]
   handles <- traverse (\i -> (i,) <$> initWorker ghcPath dbPaths i) workers
   let thePool = Pool
-        { poolStatus = IM.fromList $ map (,Nothing) workers,
+        { poolStatus = IM.fromList $ map (,(False, Nothing)) workers,
           poolHandles = handles
         }
 

--- a/server/app/Server.hs
+++ b/server/app/Server.hs
@@ -69,10 +69,10 @@ serve :: TVar Pool -> Socket -> IO ()
 serve ref s = do
   !msg <- recvMsg s
   let req :: Request = unwrapMsg msg
-      id' = requestWorkerId req
+      mid = requestWorkerId req
       env = requestEnv req
       args = requestArgs req
-  (i, hset) <- atomically $ assignJob ref id'
+  (i, hset) <- atomically $ assignJob ref mid
   dumpStatus ref
   -- putStrLn $ "id' = " ++ show id'
   -- putStrLn $ "worker = " ++ show i ++ " will handle this req."

--- a/server/app/Server.hs
+++ b/server/app/Server.hs
@@ -120,8 +120,10 @@ serve ref s = do
   !msg <- recvMsg s
   (i, hset) <- atomically $ assignJob ref
   let req :: Request = unwrapMsg msg
+      id' = requestWorkerId req
       env = requestEnv req
       args = requestArgs req
+  putStrLn $ "id' = " ++ show id'
   putStrLn $ "worker = " ++ show i ++ " will handle this req."
   let hi = handleArgIn hset
       ho = handleMsgOut hset

--- a/server/app/Server.hs
+++ b/server/app/Server.hs
@@ -73,7 +73,6 @@ serve ref s = do
       env = requestEnv req
       args = requestArgs req
   (i, hset) <- atomically $ assignJob ref mid
-  dumpStatus ref
   -- putStrLn $ "id' = " ++ show id'
   -- putStrLn $ "worker = " ++ show i ++ " will handle this req."
   let hi = handleArgIn hset
@@ -94,6 +93,7 @@ serve ref s = do
   res@(Response results _ _) <- takeMVar var
 
   putStrLn $ "worker " ++ show i ++ " returns: " ++ show results
+  dumpStatus ref
   --
   atomically $ finishJob ref i
   sendMsg s (wrapMsg res)

--- a/server/app/Server.hs
+++ b/server/app/Server.hs
@@ -18,12 +18,12 @@ import System.IO (Handle, hFlush, hGetLine, hPutStrLn)
 import System.Process (CreateProcess (std_in, std_out), StdStream (CreatePipe), createProcess, proc)
 
 runServer :: FilePath -> (Socket -> IO a) -> IO a
-runServer fp server = do
+runServer socketFile server = do
   putStrLn "Start serving"
-  withSocketsDo $ E.bracket (open fp) close loop
+  withSocketsDo $ E.bracket (open socketFile) close loop
   where
-    open f = E.bracketOnError (socket AF_UNIX Stream 0) close $ \sock -> do
-        bind sock (SockAddrUnix f)
+    open fp = E.bracketOnError (socket AF_UNIX Stream 0) close $ \sock -> do
+        bind sock (SockAddrUnix fp)
         listen sock 1024
         return sock
     loop sock = forever $ E.bracketOnError (accept sock) (close . fst)

--- a/server/app/Server.hs
+++ b/server/app/Server.hs
@@ -48,9 +48,10 @@ initWorker ghcPath dbPaths i = do
           { std_in = CreatePipe,
             std_out = CreatePipe
           }
-  (Just hstdin, Just hstdout, _, _) <- createProcess proc_setup
+  (Just hstdin, Just hstdout, _, ph) <- createProcess proc_setup
   let hset = HandleSet
-        { handleArgIn = hstdin,
+        { handleProcess = ph,
+          handleArgIn = hstdin,
           handleMsgOut = hstdout
         }
   pure hset

--- a/server/app/Server.hs
+++ b/server/app/Server.hs
@@ -88,8 +88,6 @@ work :: (Int, HandleSet) -> Request -> IO Response
 work (i, hset) req = do
   let env = requestEnv req
       args = requestArgs req
-  -- putStrLn $ "id' = " ++ show id'
-  -- putStrLn $ "worker = " ++ show i ++ " will handle this req."
   let hi = handleArgIn hset
       ho = handleMsgOut hset
   hPutStrLn hi (show (env, args))
@@ -117,9 +115,7 @@ assignLoop ghcPath dbPaths ref mid = untilJustM $ do
       putStrLn $ "currently " ++ show n ++ " jobs are running. I am spawning a worker."
       _ <- spawnWorker ghcPath dbPaths ref
       pure Nothing
-      -- atomically $ assignJob ref mid
     Right (i, hset) -> pure (Just (i, hset))
-
 
 serve :: FilePath -> [FilePath] -> TVar Pool -> Socket -> IO ()
 serve ghcPath dbPaths ref s = do
@@ -133,7 +129,7 @@ serve ghcPath dbPaths ref s = do
   when (requestWorkerClose req) $
     case mid of
       Nothing -> pure ()
-      Just id' -> atomically $ removeWorker ref id'
+      Just id' -> removeWorker ref id'
   dumpStatus ref
   serve ghcPath dbPaths ref s
 

--- a/server/ghc-persistent-worker-server.cabal
+++ b/server/ghc-persistent-worker-server.cabal
@@ -11,13 +11,11 @@ maintainer:         ianwookim@gmail.com
 category:           Development
 build-type:         Simple
 extra-doc-files:    CHANGELOG.md
--- extra-source-files:
-
-common warnings
-    ghc-options: -Wall
 
 executable Server
     main-is:          Server.hs
+    ghc-options:      -Wall -Werror
+    other-modules:    Pool
     hs-source-dirs:   app
     build-depends:    base >=4.19,
                       binary,

--- a/server/ghc-persistent-worker-server.cabal
+++ b/server/ghc-persistent-worker-server.cabal
@@ -22,6 +22,7 @@ executable Server
                       bytestring,
                       containers,
                       directory,
+                      extra,
                       filepath,
                       ghc-persistent-worker-comm,
                       network,


### PR DESCRIPTION
GHC compilation for different package modules needs to be separated to different GHC process for various reasons, such as safe dynamic linking / symbol finding and safe interface loading etc. So now each worker status is tagged with worker id and so jobs are distributed with the tag. Once done, the worker needs to be removed from the pool. 
Therefore, this intrinsically introduces dynamic pool, spawning and terminating processes as demanded.
This PR implements such dynamic mechanism and worker-id based job distribution. Worker-id assignment per different haskell target is assumed from the build system rules.