### PR TITLE
Unique Job ID per each job instances and multiplexing mailbox system to each job 

### DIFF
--- a/client/app/Client.hs
+++ b/client/app/Client.hs
@@ -10,7 +10,7 @@ import Data.Int (Int32)
 import Data.List (isPrefixOf, lookup, partition, stripPrefix)
 import Data.Monoid (First (..))
 import Message
-  ( Id (..),
+  ( TargetId (..),
     Msg (..),
     Request (..),
     Response (..),
@@ -36,7 +36,7 @@ import System.IO (hFlush, hPutStrLn, stderr, stdout)
 
 data WorkerConfig = WorkerConfig
   { workerConfigSocket :: String,
-    workerConfigId :: Maybe Id,
+    workerConfigId :: Maybe TargetId,
     workerConfigClose :: Bool
   }
   deriving (Show)
@@ -51,7 +51,7 @@ getWorkerConfig args = do
       willClose = any ("--worker-close" `isPrefixOf`) args
   pure WorkerConfig
     { workerConfigSocket = socket,
-      workerConfigId = Id <$> mid,
+      workerConfigId = TargetId <$> mid,
       workerConfigClose = willClose
     }
 
@@ -74,7 +74,7 @@ main = do
       env <- getEnvironment
       process sockPath mid willClose env ghcArgs
 
-process :: FilePath -> Maybe Id -> Bool -> [(String, String)] -> [String] -> IO ()
+process :: FilePath -> Maybe TargetId -> Bool -> [(String, String)] -> [String] -> IO ()
 process socketPath mid willClose env args = runClient socketPath $ \s -> do
   let req = Request
         { requestWorkerId = mid,

--- a/client/app/Client.hs
+++ b/client/app/Client.hs
@@ -77,7 +77,7 @@ main = do
 process :: FilePath -> Maybe TargetId -> Bool -> [(String, String)] -> [String] -> IO ()
 process socketPath mid willClose env args = runClient socketPath $ \s -> do
   let req = Request
-        { requestWorkerId = mid,
+        { requestWorkerTargetId = mid,
           requestWorkerClose = willClose,
           requestEnv = env,
           requestArgs = args

--- a/client/app/Client.hs
+++ b/client/app/Client.hs
@@ -36,7 +36,7 @@ import System.IO (hFlush, hPutStrLn, stderr, stdout)
 
 data WorkerConfig = WorkerConfig
   { workerConfigSocket :: String,
-    workerConfigId :: Maybe TargetId,
+    workerConfigTargetId :: Maybe TargetId,
     workerConfigClose :: Bool
   }
   deriving (Show)
@@ -47,11 +47,11 @@ splitArgs = partition ("--worker-" `isPrefixOf`)
 getWorkerConfig :: [String] -> Maybe WorkerConfig
 getWorkerConfig args = do
   socket <- getFirst $ foldMap (First . stripPrefix "--worker-socket=") args
-  let mid = getFirst $ foldMap (First . stripPrefix "--worker-id=") args
+  let mid = getFirst $ foldMap (First . stripPrefix "--worker-target-id=") args
       willClose = any ("--worker-close" `isPrefixOf`) args
   pure WorkerConfig
     { workerConfigSocket = socket,
-      workerConfigId = TargetId <$> mid,
+      workerConfigTargetId = TargetId <$> mid,
       workerConfigClose = willClose
     }
 
@@ -69,7 +69,7 @@ main = do
       exitFailure
     Just conf -> do
       let sockPath = workerConfigSocket conf
-          mid = workerConfigId conf
+          mid = workerConfigTargetId conf
           willClose = workerConfigClose conf
       env <- getEnvironment
       process sockPath mid willClose env ghcArgs

--- a/comm/src/Message.hs
+++ b/comm/src/Message.hs
@@ -8,7 +8,7 @@ module Message
     wrapMsg,
     unwrapMsg,
     --
-    Id (..),
+    TargetId (..),
     Request (..),
     Response (..),
   ) where
@@ -77,11 +77,11 @@ wrapMsg x =
 unwrapMsg :: (Binary a) => Msg -> a
 unwrapMsg (Msg _n bs) = decode (L.fromStrict bs)
 
-newtype Id = Id String
+newtype TargetId = TargetId String
   deriving (Show, Eq, Binary)
 
 data Request = Request
-  { requestWorkerId :: Maybe Id,
+  { requestWorkerTargetId :: Maybe TargetId,
     requestWorkerClose :: Bool,
     requestEnv :: [(String, String)],
     requestArgs :: [String]

--- a/plugin/src/GHCPersistentWorkerPlugin.hs
+++ b/plugin/src/GHCPersistentWorkerPlugin.hs
@@ -49,24 +49,31 @@ workerMain flags = do
     hSetBuffering stdout LineBuffering
     hSetBuffering stderr LineBuffering
 
-  let n :: Int = read (flags !! 0)
-      prompt = "[Worker:" ++ show n ++ "]"
+  let wid :: Int = read (flags !! 0)
+      prompt = "[Worker:" ++ show wid ++ "]"
+
   let (hin, hout) = (stdin, stdout)
   logMessage (prompt ++ " Started")
   GHC.initGhcMonad Nothing
   forever $ do
     s <- liftIO $ hGetLine hin
-    let (env, args) :: ([(String, String)], [String]) = read s
+    let (env, args0) :: ([(String, String)], [String]) = read s
+    let jid_str : args = args0
+        jid :: Int
+        jid = read jid_str
     for_ (lookup "PWD" env) $ \pwd -> liftIO $
       setCurrentDirectory pwd
     for_ env $ \(var, val) -> liftIO $
       setEnv var val
+    logMessage (prompt ++ " job id = " ++ show jid)
+    liftIO $ hPutStrLn hout (show jid)
+    liftIO $ hPutStrLn hout "*J*O*B*I*D*"
     logMessage (prompt ++ " Got args: " ++ intercalate " " args)
     --
     liftIO $ do
       mapM_ (\_ -> hPutStrLn stderr "=================================") [1..5]
       time <- getCurrentTime
-      hPutStrLn stderr $ "worker: " ++ (show n)
+      hPutStrLn stderr $ "worker: " ++ (show wid)
       hPutStrLn stderr (show time)
       mapM_ (\_ -> hPutStrLn stderr "=================================") [1..5]
     --
@@ -75,7 +82,7 @@ workerMain flags = do
     liftIO $ do
       mapM_ (\_ -> hPutStrLn stderr "|||||||||||||||||||||||||||||||||") [1..5]
       time <- getCurrentTime
-      hPutStrLn stderr $ "worker: " ++ (show n)
+      hPutStrLn stderr $ "worker: " ++ (show wid)
       hPutStrLn stderr (show time)
       mapM_ (\_ -> hPutStrLn stderr "|||||||||||||||||||||||||||||||||") [1..5]
     --

--- a/server/app/Main.hs
+++ b/server/app/Main.hs
@@ -43,7 +43,7 @@ main = do
       dbPaths = optionPkgDbs opts
   let thePool = Pool
         { poolLimit = n,
-          poolNext = 1,
+          poolNewWorkerId = 1,
           poolStatus = IM.empty,
           poolHandles = []
         }

--- a/server/app/Main.hs
+++ b/server/app/Main.hs
@@ -5,7 +5,7 @@ import Control.Monad (replicateM_)
 import qualified Data.IntMap as IM
 import Options.Applicative (Parser, (<**>))
 import qualified Options.Applicative as OA
-import Pool (Pool (..))
+import Pool (JobStatus (..), Pool (..))
 import Server (runServer, serve, spawnWorker)
 
 -- cli args
@@ -48,7 +48,9 @@ main = do
           poolStatus = IM.empty,
           poolHandles = []
         }
+      theJobStatus = JobStatus []
 
-  ref <- newTVarIO thePool
-  replicateM_ n $ spawnWorker ghcPath dbPaths ref
-  runServer socketPath (serve ghcPath dbPaths ref)
+  poolRef <- newTVarIO thePool
+  jobStatusRef <- newTVarIO theJobStatus
+  replicateM_ n $ spawnWorker ghcPath dbPaths poolRef
+  runServer socketPath (serve ghcPath dbPaths (poolRef, jobStatusRef))

--- a/server/app/Main.hs
+++ b/server/app/Main.hs
@@ -1,0 +1,53 @@
+module Main where
+
+import Control.Concurrent.STM (newTVarIO)
+import Control.Monad (replicateM_)
+import qualified Data.IntMap as IM
+import Options.Applicative (Parser, (<**>))
+import qualified Options.Applicative as OA
+import Pool (Pool (..))
+import Server (runServer, serve, spawnWorker)
+
+-- cli args
+data Option = Option
+  { optionNumWorkers :: Int,
+    optionGHC :: FilePath,
+    optionSocket :: FilePath,
+    optionPkgDbs :: [FilePath]
+  }
+
+p_option :: Parser Option
+p_option =
+  Option
+    <$> OA.option OA.auto
+        ( OA.long "num"
+            <> OA.short 'n'
+            <> OA.help "number of workers"
+        )
+    <*> OA.strOption
+        ( OA.long "ghc"
+            <> OA.help "GHC path"
+        )
+    <*> OA.strOption
+        ( OA.long "socket-file"
+            <> OA.help "UNIX socket file accepting compilation requests"
+        )
+    <*> OA.many (OA.strOption (OA.long "package-db" <> OA.help "Package DB Path"))
+
+main :: IO ()
+main = do
+  opts <- OA.execParser (OA.info (p_option <**> OA.helper) OA.fullDesc)
+  let n = optionNumWorkers opts
+      ghcPath = optionGHC opts
+      socketPath = optionSocket opts
+      dbPaths = optionPkgDbs opts
+  let thePool = Pool
+        { poolLimit = n,
+          poolNext = 1,
+          poolStatus = IM.empty,
+          poolHandles = []
+        }
+
+  ref <- newTVarIO thePool
+  replicateM_ n $ spawnWorker ghcPath dbPaths ref
+  runServer socketPath (serve ghcPath dbPaths ref)

--- a/server/app/Main.hs
+++ b/server/app/Main.hs
@@ -44,6 +44,7 @@ main = do
   let thePool = Pool
         { poolLimit = n,
           poolNewWorkerId = 1,
+          poolNewJobId = 1,
           poolStatus = IM.empty,
           poolHandles = []
         }

--- a/server/app/Main.hs
+++ b/server/app/Main.hs
@@ -5,7 +5,7 @@ import Control.Monad (replicateM_)
 import qualified Data.IntMap as IM
 import Options.Applicative (Parser, (<**>))
 import qualified Options.Applicative as OA
-import Pool (JobStatus (..), Pool (..))
+import Pool (Pool (..))
 import Server (runServer, serve, spawnWorker)
 
 -- cli args
@@ -48,9 +48,7 @@ main = do
           poolStatus = IM.empty,
           poolHandles = []
         }
-      theJobStatus = JobStatus []
 
   poolRef <- newTVarIO thePool
-  jobStatusRef <- newTVarIO theJobStatus
   replicateM_ n $ spawnWorker ghcPath dbPaths poolRef
-  runServer socketPath (serve ghcPath dbPaths (poolRef, jobStatusRef))
+  runServer socketPath (serve ghcPath dbPaths poolRef)

--- a/server/app/Pool.hs
+++ b/server/app/Pool.hs
@@ -2,9 +2,11 @@
 
 module Pool
 ( WorkerId,
+  JobId (..),
   HandleSet (..),
   Pool (..),
-  issueNewWorkerId,
+  newWorkerId,
+  newJobId,
   dumpStatus,
   assignJob,
   finishJob,
@@ -24,7 +26,8 @@ import System.Process (ProcessHandle, terminateProcess)
 type WorkerStatus = IntMap (Bool, Maybe TargetId)
 type WorkerId = Key
 
--- newtype JobId = JobId Int
+newtype JobId = JobId Int
+  deriving (Eq, Num, Ord, Show)
 
 data HandleSet = HandleSet
   { handleProcess :: ProcessHandle,
@@ -35,16 +38,24 @@ data HandleSet = HandleSet
 data Pool = Pool
   { poolLimit :: Int,
     poolNewWorkerId :: WorkerId,
+    poolNewJobId :: JobId,
     poolStatus :: WorkerStatus,
     poolHandles :: [(WorkerId, HandleSet)]
   }
 
-issueNewWorkerId :: TVar Pool -> STM WorkerId
-issueNewWorkerId ref = do
+newWorkerId :: TVar Pool -> STM WorkerId
+newWorkerId ref = do
   pool <- readTVar ref
   let i = poolNewWorkerId pool
   writeTVar ref (pool {poolNewWorkerId = i + 1})
   pure i
+
+newJobId :: TVar Pool -> STM JobId
+newJobId ref = do
+  pool <- readTVar ref
+  let JobId i = poolNewJobId pool
+  writeTVar ref (pool {poolNewJobId = JobId (i + 1)})
+  pure (JobId i)
 
 dumpStatus :: TVar Pool -> IO ()
 dumpStatus ref = do
@@ -70,7 +81,7 @@ assignJob ::
   TVar Pool ->
   Maybe TargetId ->
   -- | Right assigned, Left new id that will be used for new spawned worker process.
-  STM (Either Int (WorkerId, HandleSet))
+  STM (Either Int (JobId, WorkerId, HandleSet))
 assignJob ref mid' = do
   pool <- readTVar ref
   let workers = poolStatus pool
@@ -81,13 +92,14 @@ assignJob ref mid' = do
       if (nRunningJobs >= poolLimit pool)
         then retry
         else pure (Left nRunningJobs)
-    Just (i, _) -> do
+    Just (wid, _) -> do
       let upd (_, Nothing) = Just (True, mid')
           upd (_, Just id'') = Just (True, Just id'')
-          !workers' = IM.update upd i workers
-          Just hset = List.lookup i (poolHandles pool)
+          !workers' = IM.update upd wid workers
+          Just hset = List.lookup wid (poolHandles pool)
       writeTVar ref (pool {poolStatus = workers'})
-      pure $ Right (i, hset)
+      jid <- newJobId ref
+      pure $ Right (jid, wid, hset)
 
 finishJob :: TVar Pool -> WorkerId -> STM ()
 finishJob ref i = do
@@ -108,4 +120,3 @@ removeWorker ref id' = mask $ \_restore -> do
       writeTVar ref (pool {poolStatus = remained, poolHandles = remainedHandles})
       pure (fmap (handleProcess . snd) dismissedHandles)
   mapM_ terminateProcess dismissedHandles
-

--- a/server/app/Pool.hs
+++ b/server/app/Pool.hs
@@ -31,9 +31,9 @@ data HandleSet = HandleSet
 
 data Pool = Pool
   { poolLimit :: Int,
-    poolNext :: Int,
+    poolNext :: WorkerId,
     poolStatus :: WorkerStatus,
-    poolHandles :: [(Int, HandleSet)]
+    poolHandles :: [(WorkerId, HandleSet)]
   }
 
 dumpStatus :: TVar Pool -> IO ()

--- a/server/app/Pool.hs
+++ b/server/app/Pool.hs
@@ -5,6 +5,7 @@ module Pool
   JobId (..),
   HandleSet (..),
   Pool (..),
+  JobStatus (..),
   newWorkerId,
   newJobId,
   dumpStatus,
@@ -13,13 +14,13 @@ module Pool
   removeWorker,
 ) where
 
-import Control.Concurrent.STM (STM, TVar, atomically, readTVar, retry, writeTVar)
+import Control.Concurrent.STM (STM, TChan, TVar, atomically, readTVar, retry, writeTVar)
 import Control.Exception (mask)
 import qualified Data.Foldable as F
 import Data.IntMap (IntMap, Key)
 import qualified Data.IntMap as IM
 import qualified Data.List as List
-import Message (TargetId)
+import Message (Response, TargetId)
 import System.IO (Handle, hFlush, hPrint, hPutStrLn, stdout)
 import System.Process (ProcessHandle, terminateProcess)
 
@@ -41,6 +42,10 @@ data Pool = Pool
     poolNewJobId :: JobId,
     poolStatus :: WorkerStatus,
     poolHandles :: [(WorkerId, HandleSet)]
+  }
+
+data JobStatus = JobStatus
+  { jobStatusChan :: [(JobId, TChan Response)]
   }
 
 newWorkerId :: TVar Pool -> STM WorkerId

--- a/server/app/Server.hs
+++ b/server/app/Server.hs
@@ -23,7 +23,7 @@ import Network.Socket
     socket,
     withSocketsDo,
   )
-import Pool (HandleSet (..), Pool (..), WorkerId, assignJob, dumpStatus, finishJob, removeWorker)
+import Pool (HandleSet (..), Pool (..), WorkerId, assignJob, dumpStatus, finishJob, issueNewWorkerId, removeWorker)
 import System.Process (CreateProcess (std_in, std_out), StdStream (CreatePipe), createProcess, proc)
 import Worker (work)
 
@@ -68,11 +68,7 @@ initWorker ghcPath dbPaths i = do
 
 spawnWorker :: FilePath -> [FilePath] -> TVar Pool -> IO (WorkerId, HandleSet)
 spawnWorker ghcPath dbPaths ref = do
-  i <- atomically $ do
-    pool <- readTVar ref
-    let i = poolNext pool
-    writeTVar ref (pool {poolNext = i + 1})
-    pure i
+  i <- atomically $ issueNewWorkerId ref
   hset <- initWorker ghcPath dbPaths i
   atomically $ do
     pool <- readTVar ref

--- a/server/app/Worker.hs
+++ b/server/app/Worker.hs
@@ -1,14 +1,32 @@
-module Worker (work) where
+{-# OPTIONS_GHC -w #-}
+module Worker
+( Mailbox (..),
+  mailboxForWorker,
+  work,
+) where
 
 import Control.Concurrent (forkIO)
-import Control.Concurrent.STM (TVar, atomically, modifyTVar, newTChan, readTChan, writeTChan, readTVar, writeTVar)
+import Control.Concurrent.STM
+  ( STM,
+    TChan,
+    TVar,
+    atomically,
+    modifyTVar,
+    newTChan,
+    readTChan,
+    writeTChan,
+    readTVar,
+    retry,
+    writeTVar,
+  )
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Reader (ReaderT, ask)
-import Pool (HandleSet (..), JobId, JobStatus (..), Pool, WorkerId, finishJob)
+import qualified Data.List as L
+import Pool (HandleSet (..), JobId, Mailbox (..), Pool (..), WorkerId, finishJob)
 import Message (Request (..), Response (..))
 import System.IO (Handle, hFlush, hGetLine, hPutStrLn)
 
-type JobM = ReaderT (JobId, WorkerId, HandleSet, TVar Pool, TVar JobStatus) IO
+type JobM = ReaderT (JobId, WorkerId, HandleSet, TVar Pool) IO
 
 fetchUntil :: String -> Handle -> IO [String]
 fetchUntil delim h = do
@@ -21,22 +39,35 @@ fetchUntil delim h = do
         then pure acc
         else go (acc . (s:))
 
+mailboxForWorker :: TVar Pool -> IO ()
+mailboxForWorker _poolRef = pure ()
+
+addJobChan :: TVar Pool -> WorkerId -> JobId -> STM (TChan Response, HandleSet)
+addJobChan poolRef wid jid = do
+  pool <- readTVar poolRef
+  let hsets = poolHandles pool
+  case L.lookup wid hsets of
+    Nothing -> retry
+    Just hset -> do
+      chan <- newTChan
+      let Mailbox lst = handleMailbox hset
+          hset' = hset {handleMailbox = Mailbox ((jid, chan) : lst)}
+          hsets' = (wid, hset') : (filter ((/= wid) . fst) hsets)
+      writeTVar poolRef pool {poolHandles = hsets'}
+      pure (chan, hset')
+
 work :: Request -> JobM Response
 work req = do
-  (j, i, hset, poolRef, jobStatusRef) <- ask
+  (jid, wid, hset, poolRef) <- ask
   let env = requestEnv req
       args = requestArgs req
   let hi = handleArgIn hset
       ho = handleMsgOut hset
-  liftIO $ print j
+  liftIO $ print jid
   liftIO $ do
     hPutStrLn hi (show (env, args))
     hFlush hi
-  chan <- liftIO $ atomically $ do
-    c <- newTChan
-    JobStatus lst <- readTVar jobStatusRef
-    writeTVar jobStatusRef (JobStatus ((j, c) : lst))
-    pure c
+  (chan, _) <- liftIO $ atomically $ addJobChan poolRef wid jid
   _ <- liftIO $ forkIO $ do
     -- get stdout until delimiter
     console_stdout <- fetchUntil "*S*T*D*O*U*T*" ho
@@ -50,11 +81,11 @@ work req = do
 
   res@(Response results _ _) <- liftIO $ atomically $ do
     r <- readTChan chan
-    finishJob poolRef i
-    modifyTVar jobStatusRef $ \(JobStatus lst) ->
-      let lst' = filter ((j /=) . fst) lst
-       in JobStatus lst'
+    finishJob poolRef wid
+    -- modifyTVar mailboxRef $ \(Mailbox lst) ->
+    --   let lst' = filter ((j /=) . fst) lst
+    --    in Mailbox lst'
     pure r
 
-  liftIO $ putStrLn $ "worker " ++ show i ++ " returns: " ++ show results
+  liftIO $ putStrLn $ "worker " ++ show wid ++ " returns: " ++ show results
   pure res

--- a/server/app/Worker.hs
+++ b/server/app/Worker.hs
@@ -1,0 +1,48 @@
+module Worker (work) where
+
+import Control.Concurrent (forkIO)
+import Control.Concurrent.STM (atomically, newTChanIO, readTChan, writeTChan)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Trans.Reader (ReaderT, ask)
+import Pool (HandleSet (..), WorkerId)
+import Message (Request (..), Response (..))
+import System.IO (Handle, hFlush, hGetLine, hPutStrLn)
+
+type WorkInstance = ReaderT (WorkerId, HandleSet) IO
+
+fetchUntil :: String -> Handle -> IO [String]
+fetchUntil delim h = do
+    f <- go id
+    pure (f [])
+  where
+    go acc = do
+      s <- hGetLine h
+      if s == delim
+        then pure acc
+        else go (acc . (s:))
+
+work :: Request -> WorkInstance Response
+work req = do
+  (i, hset) <- ask
+  let env = requestEnv req
+      args = requestArgs req
+  let hi = handleArgIn hset
+      ho = handleMsgOut hset
+  liftIO $ do
+    hPutStrLn hi (show (env, args))
+    hFlush hi
+  chan <- liftIO newTChanIO
+  _ <- liftIO $ forkIO $ do
+    -- get stdout until delimiter
+    console_stdout <- fetchUntil "*S*T*D*O*U*T*" ho
+    -- get result metatdata until delimiter
+    results <- fetchUntil "*R*E*S*U*L*T*" ho
+    -- get stderr until delimiter
+    console_stderr <- fetchUntil "*D*E*L*I*M*I*T*E*D*" ho
+    let res = Response results console_stdout console_stderr
+    -- putMVar var res
+    atomically $ writeTChan chan res
+
+  res@(Response results _ _) <- liftIO $ atomically $ readTChan chan
+  liftIO $ putStrLn $ "worker " ++ show i ++ " returns: " ++ show results
+  pure res

--- a/server/app/Worker.hs
+++ b/server/app/Worker.hs
@@ -8,7 +8,7 @@ import Pool (HandleSet (..), WorkerId)
 import Message (Request (..), Response (..))
 import System.IO (Handle, hFlush, hGetLine, hPutStrLn)
 
-type WorkInstance = ReaderT (WorkerId, HandleSet) IO
+type JobM = ReaderT (WorkerId, HandleSet) IO
 
 fetchUntil :: String -> Handle -> IO [String]
 fetchUntil delim h = do
@@ -21,7 +21,7 @@ fetchUntil delim h = do
         then pure acc
         else go (acc . (s:))
 
-work :: Request -> WorkInstance Response
+work :: Request -> JobM Response
 work req = do
   (i, hset) <- ask
   let env = requestEnv req

--- a/server/ghc-persistent-worker-server.cabal
+++ b/server/ghc-persistent-worker-server.cabal
@@ -17,6 +17,7 @@ executable Server
     ghc-options:      -Wall -Werror
     other-modules:    Pool
                       Server
+                      Worker
     hs-source-dirs:   app
     build-depends:    base >=4.19,
                       binary,
@@ -30,5 +31,6 @@ executable Server
                       optparse-applicative,
                       process,
                       stm,
+                      transformers,
                       unix
     default-language: GHC2021

--- a/server/ghc-persistent-worker-server.cabal
+++ b/server/ghc-persistent-worker-server.cabal
@@ -13,9 +13,10 @@ build-type:         Simple
 extra-doc-files:    CHANGELOG.md
 
 executable Server
-    main-is:          Server.hs
+    main-is:          Main.hs
     ghc-options:      -Wall -Werror
     other-modules:    Pool
+                      Server
     hs-source-dirs:   app
     build-depends:    base >=4.19,
                       binary,


### PR DESCRIPTION
In preparation of multiplexing persistent worker (single GHC process handling multiple compilation requests in parallel by multithreading), per-process message channel via stdin/stdout pipe need to be multiplexed to branching message channels per job (assigned to a unique id) like mailbox. 