### PR TITLE
Threaded persistent worker with log redirection

### DIFF
--- a/plugin/ghc-persistent-worker-plugin.cabal
+++ b/plugin/ghc-persistent-worker-plugin.cabal
@@ -24,11 +24,13 @@ library
     if (impl(ghc > 9.11))
         hs-source-dirs: src-ghcHEAD
         other-modules:  GHC.Main
+                        Logger
         build-depends: base ^>=4.20,
 
     if (impl(ghc >= 9.8) && impl(ghc < 9.9))
         hs-source-dirs: src-ghc98
         other-modules:  GHC.Main
+                        Logger
         build-depends: base ^>=4.19,
 
     build-depends:    binary,

--- a/plugin/src-ghc98/Logger.hs
+++ b/plugin/src-ghc98/Logger.hs
@@ -1,0 +1,61 @@
+module Logger where
+
+--
+-- override defaultLogAction. Redirect stdout/stderr to accumulated bytestring
+--
+logHook :: (Handle, Handle) -> LogAction -> LogAction
+logHook (nstdout, nstderr) _ =
+  \logflags msg_class srcSpan msg ->
+    if (log_dopt Opt_D_dump_json logflags)
+    then jsonLogAction'
+    else case msg_class of
+      MCOutput                     -> printOut msg
+      MCDump                       -> printOut (msg $$ blankLine)
+      MCInteractive                -> putStrSDoc msg
+      MCInfo                       -> printErrs msg
+      MCFatal                      -> printErrs msg
+      MCDiagnostic SevIgnore _ _   -> pure () -- suppress the message
+      MCDiagnostic _sev _rea _code -> printDiagnostics
+    where
+      printOut   = defaultLogActionHPrintDoc  logflags False nstdout
+      printErrs  = defaultLogActionHPrintDoc  logflags False nstderr
+      putStrSDoc = defaultLogActionHPutStrDoc logflags False nstdout
+      -- Pretty print the warning flag, if any (#10752)
+      message = mkLocMessageWarningGroups (log_show_warn_groups logflags) msg_class srcSpan msg
+
+      printDiagnostics = do
+        caretDiagnostic <-
+            if log_show_caret logflags
+            then getCaretDiagnostic msg_class srcSpan
+            else pure empty
+        printErrs $ getPprStyle $ \style ->
+          withPprStyle (setStyleColoured True style)
+            (message $+$ caretDiagnostic $+$ blankLine)
+        -- careful (#2302): printErrs prints in UTF-8,
+        -- whereas converting to string first and using
+        -- hPutStr would just emit the low 8 bits of
+        -- each unicode char.
+ 
+      jsonLogAction' :: LogAction
+      jsonLogAction' _ (MCDiagnostic SevIgnore _ _) _ _ = return () -- suppress the message
+      jsonLogAction' logflags msg_class srcSpan msg
+        =
+          defaultLogActionHPutStrDoc logflags True nstdout
+            (withPprStyle PprCode (doc $$ text ""))
+          where
+            str = renderWithContext (log_default_user_context logflags) msg
+            doc = renderJSON $
+                    JSObject [ ( "span", spanToDumpJSON srcSpan )
+                             , ( "doc" , JSString str )
+                             , ( "messageClass", json msg_class )
+                             ]
+            spanToDumpJSON :: SrcSpan -> JsonDoc
+            spanToDumpJSON s = case s of
+                       (RealSrcSpan rss _) -> JSObject [ ("file", json file)
+                                                      , ("startLine", json $ srcSpanStartLine rss)
+                                                      , ("startCol", json $ srcSpanStartCol rss)
+                                                      , ("endLine", json $ srcSpanEndLine rss)
+                                                      , ("endCol", json $ srcSpanEndCol rss)
+                                                      ]
+                         where file = unpackFS $ srcSpanFile rss
+                       UnhelpfulSpan _ -> JSNull

--- a/plugin/src-ghc98/Logger.hs
+++ b/plugin/src-ghc98/Logger.hs
@@ -1,14 +1,38 @@
-module Logger where
+module Logger (logHook) where
+
+import GHC.Data.FastString (unpackFS)
+import GHC.Driver.Flags (DumpFlag (Opt_D_dump_json))
+import GHC.Types.Error (MessageClass (..), Severity (..), getCaretDiagnostic, mkLocMessageWarningGroups)
+import GHC.Utils.Json (JsonDoc (..), ToJson (json), renderJSON)
+import GHC.Utils.Logger
+  ( LogAction,
+    LogFlags (..),
+    defaultLogActionHPrintDoc,
+    defaultLogActionHPutStrDoc,
+    log_dopt,
+  )
+import GHC.Utils.Outputable
+  ( PprStyle (PprCode),
+    blankLine,
+    empty,
+    getPprStyle,
+    renderWithContext,
+    setStyleColoured,
+    text,
+    withPprStyle,
+    ($$),
+    ($+$),
+  )
+import GHC.Types.SrcLoc (SrcSpan (..), RealSrcSpan (..), srcSpanEndCol, srcSpanEndLine, srcSpanStartCol, srcSpanStartLine)
+import System.IO (Handle)
 
 --
 -- override defaultLogAction. Redirect stdout/stderr to accumulated bytestring
 --
 logHook :: (Handle, Handle) -> LogAction -> LogAction
-logHook (nstdout, nstderr) _ =
-  \logflags msg_class srcSpan msg ->
-    if (log_dopt Opt_D_dump_json logflags)
-    then jsonLogAction'
-    else case msg_class of
+logHook (nstdout, nstderr) _ logflags msg_class srcSpan msg
+  | log_dopt Opt_D_dump_json logflags = jsonLogAction' logflags msg_class srcSpan msg
+  | otherwise = case msg_class of
       MCOutput                     -> printOut msg
       MCDump                       -> printOut (msg $$ blankLine)
       MCInteractive                -> putStrSDoc msg
@@ -16,46 +40,46 @@ logHook (nstdout, nstderr) _ =
       MCFatal                      -> printErrs msg
       MCDiagnostic SevIgnore _ _   -> pure () -- suppress the message
       MCDiagnostic _sev _rea _code -> printDiagnostics
-    where
-      printOut   = defaultLogActionHPrintDoc  logflags False nstdout
-      printErrs  = defaultLogActionHPrintDoc  logflags False nstderr
-      putStrSDoc = defaultLogActionHPutStrDoc logflags False nstdout
-      -- Pretty print the warning flag, if any (#10752)
-      message = mkLocMessageWarningGroups (log_show_warn_groups logflags) msg_class srcSpan msg
+  where
+    printOut   = defaultLogActionHPrintDoc  logflags False nstdout
+    printErrs  = defaultLogActionHPrintDoc  logflags False nstderr
+    putStrSDoc = defaultLogActionHPutStrDoc logflags False nstdout
+    -- Pretty print the warning flag, if any (#10752)
+    message = mkLocMessageWarningGroups (log_show_warn_groups logflags) msg_class srcSpan msg
 
-      printDiagnostics = do
-        caretDiagnostic <-
-            if log_show_caret logflags
-            then getCaretDiagnostic msg_class srcSpan
-            else pure empty
-        printErrs $ getPprStyle $ \style ->
-          withPprStyle (setStyleColoured True style)
-            (message $+$ caretDiagnostic $+$ blankLine)
-        -- careful (#2302): printErrs prints in UTF-8,
-        -- whereas converting to string first and using
-        -- hPutStr would just emit the low 8 bits of
-        -- each unicode char.
- 
-      jsonLogAction' :: LogAction
-      jsonLogAction' _ (MCDiagnostic SevIgnore _ _) _ _ = return () -- suppress the message
-      jsonLogAction' logflags msg_class srcSpan msg
-        =
-          defaultLogActionHPutStrDoc logflags True nstdout
-            (withPprStyle PprCode (doc $$ text ""))
-          where
-            str = renderWithContext (log_default_user_context logflags) msg
-            doc = renderJSON $
-                    JSObject [ ( "span", spanToDumpJSON srcSpan )
-                             , ( "doc" , JSString str )
-                             , ( "messageClass", json msg_class )
-                             ]
-            spanToDumpJSON :: SrcSpan -> JsonDoc
-            spanToDumpJSON s = case s of
-                       (RealSrcSpan rss _) -> JSObject [ ("file", json file)
-                                                      , ("startLine", json $ srcSpanStartLine rss)
-                                                      , ("startCol", json $ srcSpanStartCol rss)
-                                                      , ("endLine", json $ srcSpanEndLine rss)
-                                                      , ("endCol", json $ srcSpanEndCol rss)
-                                                      ]
-                         where file = unpackFS $ srcSpanFile rss
-                       UnhelpfulSpan _ -> JSNull
+    printDiagnostics = do
+      caretDiagnostic <-
+          if log_show_caret logflags
+          then getCaretDiagnostic msg_class srcSpan
+          else pure empty
+      printErrs $ getPprStyle $ \style ->
+        withPprStyle (setStyleColoured True style)
+          (message $+$ caretDiagnostic $+$ blankLine)
+      -- careful (#2302): printErrs prints in UTF-8,
+      -- whereas converting to string first and using
+      -- hPutStr would just emit the low 8 bits of
+      -- each unicode char.
+
+    jsonLogAction' :: LogAction
+    jsonLogAction' _ (MCDiagnostic SevIgnore _ _) _ _ = return () -- suppress the message
+    jsonLogAction' logflags msg_class srcSpan msg
+      =
+        defaultLogActionHPutStrDoc logflags True nstdout
+          (withPprStyle PprCode (doc $$ text ""))
+        where
+          str = renderWithContext (log_default_user_context logflags) msg
+          doc = renderJSON $
+                  JSObject [ ( "span", spanToDumpJSON srcSpan )
+                           , ( "doc" , JSString str )
+                           , ( "messageClass", json msg_class )
+                           ]
+          spanToDumpJSON :: SrcSpan -> JsonDoc
+          spanToDumpJSON s = case s of
+                     (RealSrcSpan rss _) -> JSObject [ ("file", json file)
+                                                    , ("startLine", json $ srcSpanStartLine rss)
+                                                    , ("startCol", json $ srcSpanStartCol rss)
+                                                    , ("endLine", json $ srcSpanEndLine rss)
+                                                    , ("endCol", json $ srcSpanEndCol rss)
+                                                    ]
+                       where file = unpackFS $ srcSpanFile rss
+                     UnhelpfulSpan _ -> JSNull

--- a/plugin/src-ghcHEAD/Logger.hs
+++ b/plugin/src-ghcHEAD/Logger.hs
@@ -33,8 +33,7 @@ logHook :: (Handle, Handle) -> LogAction -> LogAction
 logHook (nstdout, nstderr) _ logflags msg_class srcSpan msg
   | log_dopt Opt_D_dump_json logflags = jsonLogAction' logflags msg_class srcSpan msg
   | otherwise = case msg_class of
-      MCOutput                     -> -- putStrLn "AHAHAHAHA" >>
-                                      printOut msg
+      MCOutput                     -> printOut msg
       MCDump                       -> printOut (msg $$ blankLine)
       MCInteractive                -> putStrSDoc msg
       MCInfo                       -> printErrs msg

--- a/plugin/src-ghcHEAD/Logger.hs
+++ b/plugin/src-ghcHEAD/Logger.hs
@@ -1,0 +1,86 @@
+module Logger (logHook) where
+
+import GHC.Data.FastString (unpackFS)
+import GHC.Driver.Flags (DumpFlag (Opt_D_dump_json))
+import GHC.Types.Error (MessageClass (..), Severity (..), getCaretDiagnostic, mkLocMessageWarningGroups)
+import GHC.Utils.Json (JsonDoc (..), ToJson (json), renderJSON)
+import GHC.Utils.Logger
+  ( LogAction,
+    LogFlags (..),
+    defaultLogActionHPrintDoc,
+    defaultLogActionHPutStrDoc,
+    log_dopt,
+  )
+import GHC.Utils.Outputable
+  ( PprStyle (PprCode),
+    blankLine,
+    empty,
+    getPprStyle,
+    renderWithContext,
+    setStyleColoured,
+    text,
+    withPprStyle,
+    ($$),
+    ($+$),
+  )
+import GHC.Types.SrcLoc (SrcSpan (..), RealSrcSpan (..), srcSpanEndCol, srcSpanEndLine, srcSpanStartCol, srcSpanStartLine)
+import System.IO (Handle)
+
+--
+-- override defaultLogAction. Redirect stdout/stderr to accumulated bytestring
+--
+logHook :: (Handle, Handle) -> LogAction -> LogAction
+logHook (nstdout, nstderr) _ logflags msg_class srcSpan msg
+  | log_dopt Opt_D_dump_json logflags = jsonLogAction' logflags msg_class srcSpan msg
+  | otherwise = case msg_class of
+      MCOutput                     -> -- putStrLn "AHAHAHAHA" >>
+                                      printOut msg
+      MCDump                       -> printOut (msg $$ blankLine)
+      MCInteractive                -> putStrSDoc msg
+      MCInfo                       -> printErrs msg
+      MCFatal                      -> printErrs msg
+      MCDiagnostic SevIgnore _ _   -> pure () -- suppress the message
+      MCDiagnostic _sev _rea _code -> printDiagnostics
+  where
+    printOut   = defaultLogActionHPrintDoc  logflags False nstdout
+    printErrs  = defaultLogActionHPrintDoc  logflags False nstderr
+    putStrSDoc = defaultLogActionHPutStrDoc logflags False nstdout
+    -- Pretty print the warning flag, if any (#10752)
+    message = mkLocMessageWarningGroups (log_show_warn_groups logflags) msg_class srcSpan msg
+
+    printDiagnostics = do
+      caretDiagnostic <-
+          if log_show_caret logflags
+          then getCaretDiagnostic msg_class srcSpan
+          else pure empty
+      printErrs $ getPprStyle $ \style ->
+        withPprStyle (setStyleColoured True style)
+          (message $+$ caretDiagnostic $+$ blankLine)
+      -- careful (#2302): printErrs prints in UTF-8,
+      -- whereas converting to string first and using
+      -- hPutStr would just emit the low 8 bits of
+      -- each unicode char.
+
+    jsonLogAction' :: LogAction
+    jsonLogAction' _ (MCDiagnostic SevIgnore _ _) _ _ = return () -- suppress the message
+    jsonLogAction' logflags msg_class srcSpan msg
+      =
+        defaultLogActionHPutStrDoc logflags True nstdout
+          (withPprStyle PprCode (doc $$ text ""))
+        where
+          str = renderWithContext (log_default_user_context logflags) msg
+          doc = renderJSON $
+                  JSObject [ ( "span", spanToDumpJSON srcSpan )
+                           , ( "doc" , JSString str )
+                           , ( "messageClass", json msg_class )
+                           ]
+          spanToDumpJSON :: SrcSpan -> JsonDoc
+          spanToDumpJSON s = case s of
+                     (RealSrcSpan rss _) -> JSObject [ ("file", json file)
+                                                    , ("startLine", json $ srcSpanStartLine rss)
+                                                    , ("startCol", json $ srcSpanStartCol rss)
+                                                    , ("endLine", json $ srcSpanEndLine rss)
+                                                    , ("endCol", json $ srcSpanEndCol rss)
+                                                    ]
+                       where file = unpackFS $ srcSpanFile rss
+                     UnhelpfulSpan _ -> JSNull

--- a/server/app/Server.hs
+++ b/server/app/Server.hs
@@ -83,13 +83,12 @@ spawnWorker ghcPath dbPaths poolRef = do
   atomically $ do
     pool <- readTVar poolRef
     let s = poolStatus pool
-        s' = IM.insert wid (False, Nothing) s
+        s' = IM.insert wid (0, Nothing) s
         ihsets = poolHandles pool
         ihsets' = (wid, hset) : ihsets
     writeTVar poolRef (pool {poolStatus = s', poolHandles = ihsets'})
   mailboxForWorker poolRef wid (handleMsgOut hset)
   pure (wid, hset)
-
 
 assignLoop :: FilePath -> [FilePath] -> TVar Pool -> Maybe TargetId -> IO (JobId, WorkerId, HandleSet)
 assignLoop ghcPath dbPaths poolRef mid = untilJustM $ do

--- a/server/app/Worker.hs
+++ b/server/app/Worker.hs
@@ -47,7 +47,7 @@ mailboxForWorker poolRef wid hout = void (forkIO $ forever go)
     blockUntilActive = do
       pool <- readTVar poolRef
       case fst <$> IM.lookup wid (poolStatus pool) of
-        Just True -> pure ()
+        Just n | n > 0 -> pure ()
         _ -> retry
     sendResult jobid res = do
       pool <- readTVar poolRef


### PR DESCRIPTION
It is still handling a single job at a time, but incoming jobs are performed in a spawned thread, and the stdout/stderr outputs and logs are redirected to temporary files by logger hook. 
Preliminary step towards a true multiplexed worker.