### PR TITLE
buck-worker improvement and prepare for full integration

### DIFF
--- a/buck-worker/AbiHash.hs
+++ b/buck-worker/AbiHash.hs
@@ -1,5 +1,3 @@
-{-# language BlockArguments, DerivingStrategies #-}
-
 module AbiHash where
 
 import Control.Monad.IO.Class (MonadIO (liftIO))

--- a/buck-worker/Args.hs
+++ b/buck-worker/Args.hs
@@ -1,5 +1,3 @@
-{-# language BlockArguments, LambdaCase, DerivingStrategies, RecordWildCards, OverloadedRecordDot #-}
-
 module Args where
 
 import Data.Foldable (for_)

--- a/buck-worker/Args.hs
+++ b/buck-worker/Args.hs
@@ -3,6 +3,8 @@ module Args where
 import AbiHash (AbiHash (..))
 import Data.Foldable (for_)
 import Data.Int (Int32)
+import Data.Map (Map)
+import Data.Map.Strict ((!?))
 
 data Args =
   Args {
@@ -11,6 +13,7 @@ data Args =
     buck2PackageDb :: [String],
     buck2PackageDbDep :: Maybe String,
     binPath :: [String],
+    tempDir :: Maybe String,
     ghcDirFile :: Maybe String,
     ghcDbFile :: Maybe String,
     ghcOptions :: [String]
@@ -23,14 +26,15 @@ data CompileResult =
   }
   deriving stock (Eq, Show)
 
-emptyArgs :: Args
-emptyArgs =
+emptyArgs :: Map String String -> Args
+emptyArgs env =
   Args {
     abiOut = Nothing,
     buck2Dep = Nothing,
     buck2PackageDb = [],
     buck2PackageDbDep = Nothing,
     binPath = [],
+    tempDir = env !? "TMPDIR",
     ghcDirFile = Nothing,
     ghcDbFile = Nothing,
     ghcOptions = []

--- a/buck-worker/Args.hs
+++ b/buck-worker/Args.hs
@@ -41,7 +41,7 @@ parseBuckArgs =
     spin Args {..} = \case
       "--abi-out" : rest -> takeArg "--abi-out" rest \ v -> Args {abiOut = Just v, ..}
       "--buck2-dep" : rest -> takeArg "--buck2-dep" rest \ v -> Args {buck2Dep = Just v, ..}
-      "--buck2-packagedb" : rest -> takeArg "--buck2-packagedb" rest \ v -> Args {buck2PackageDb = v : buck2PackageDb, ..}
+      "--buck2-package-db" : rest -> takeArg "--buck2-package-db" rest \ v -> Args {buck2PackageDb = v : buck2PackageDb, ..}
       "--buck2-packagedb-dep" : rest -> takeArg "--buck2-packagedb-dep" rest \ v -> Args {buck2PackageDbDep = Just v, ..}
       "--ghc" : rest -> takeArg "--ghc" rest \ _ -> Args {ghcOptions = [], ..}
       "--ghc-dir" : rest -> takeArg "--ghc-dir" rest \ f -> Args {ghcOptions = [], ghcDirFile = Just f, ..}

--- a/buck-worker/Args.hs
+++ b/buck-worker/Args.hs
@@ -1,7 +1,7 @@
 module Args where
 
-import Data.Foldable (for_)
 import AbiHash (AbiHash (..))
+import Data.Foldable (for_)
 import Data.Int (Int32)
 
 data Args =
@@ -10,6 +10,7 @@ data Args =
     buck2Dep :: Maybe String,
     buck2PackageDb :: [String],
     buck2PackageDbDep :: Maybe String,
+    binPath :: [String],
     ghcDirFile :: Maybe String,
     ghcDbFile :: Maybe String,
     ghcOptions :: [String]
@@ -29,14 +30,15 @@ emptyArgs =
     buck2Dep = Nothing,
     buck2PackageDb = [],
     buck2PackageDbDep = Nothing,
+    binPath = [],
     ghcDirFile = Nothing,
     ghcDbFile = Nothing,
     ghcOptions = []
   }
 
-parseBuckArgs :: [String] -> Either String Args
-parseBuckArgs =
-  spin emptyArgs
+parseBuckArgs :: Map String String -> [String] -> Either String Args
+parseBuckArgs env =
+  spin (emptyArgs env)
   where
     spin Args {..} = \case
       "--abi-out" : rest -> takeArg "--abi-out" rest \ v -> Args {abiOut = Just v, ..}
@@ -46,6 +48,7 @@ parseBuckArgs =
       "--ghc" : rest -> takeArg "--ghc" rest \ _ -> Args {ghcOptions = [], ..}
       "--ghc-dir" : rest -> takeArg "--ghc-dir" rest \ f -> Args {ghcOptions = [], ghcDirFile = Just f, ..}
       "--extra-pkg-db" : rest -> takeArg "--extra-pkg-db" rest \ f -> Args {ghcOptions = [], ghcDbFile = Just f, ..}
+      "--bin-path" : rest -> takeArg "--bin-path" rest \ v -> Args {binPath = v : binPath, ..}
       "-c" : rest -> spin Args {ghcOptions = ghcOptions, ..} rest
       arg : rest -> spin Args {ghcOptions = arg : ghcOptions, ..} rest
       [] -> Right Args {ghcOptions = reverse ghcOptions, ..}

--- a/buck-worker/Cache.hs
+++ b/buck-worker/Cache.hs
@@ -1,32 +1,399 @@
-{-# language BlockArguments #-}
-
 module Cache where
 
-import Control.Monad.IO.Class (liftIO)
+import Control.Concurrent.MVar (MVar, modifyMVar, modifyMVar_, newMVar, readMVar)
+import Control.Monad (unless)
+import Control.Monad.Catch (finally)
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Data.Bifunctor (first)
+import Data.Coerce (coerce)
 import Data.Foldable (for_, traverse_)
-import Data.IORef (IORef, readIORef, writeIORef)
-import GHC (Ghc)
+import qualified Data.Map.Strict as Map
+import Data.Map.Strict (Map)
+import Data.Maybe (fromMaybe)
+import qualified Data.Set as Set
+import Data.Set ((\\))
+import GHC (Ghc, moduleName, moduleNameString)
+import GHC.Data.FastString (FastString)
 import GHC.Driver.Env (HscEnv (..))
-import GHC.Driver.Monad (modifySession, withSession)
-import GHC.Runtime.Interpreter (Interp)
+import GHC.Driver.Monad (withSession)
+import GHC.Linker.Loader (initLoaderState)
+import GHC.Linker.Types (LinkerEnv (..), Loader (..), LoaderState (..))
+import GHC.Ptr (Ptr)
+import GHC.Runtime.Interpreter (Interp (..))
+import GHC.Types.Name.Cache (NameCache (..), OrigNameCache)
+import GHC.Types.Unique.DFM (plusUDFM)
+import GHC.Types.Unique.FM (UniqFM, minusUFM, nonDetEltsUFM, sizeUFM)
+import GHC.Types.Unique.Supply (initUniqSupply)
+import GHC.Unit.Module.Env (emptyModuleEnv, moduleEnvKeys, plusModuleEnv)
+import qualified GHC.Utils.Outputable as Outputable
+import GHC.Utils.Outputable (comma, fsep, hang, punctuate, text, ($$), (<+>))
+import Log (Log, logOther, logd)
 
-data Cache =
-  Cache {
-    interp :: Interp
+newtype SymbolCache =
+  SymbolCache { get :: UniqFM FastString (Ptr ()) }
+  deriving newtype (Semigroup)
+
+data LinkerStats =
+  LinkerStats {
+    newClosures :: Int,
+    newItables :: Int
+  }
+  deriving stock (Eq, Show)
+
+emptyLinkerStats :: LinkerStats
+emptyLinkerStats =
+  LinkerStats {
+    newClosures = 0,
+    newItables = 0
   }
 
-type CacheRef = IORef (Maybe Cache)
+data LoaderStats =
+  LoaderStats {
+    newBcos :: [String],
+    sameBcos :: Int,
+    linker :: LinkerStats
+  }
+  deriving stock (Eq, Show)
 
-withCache :: CacheRef -> Ghc a -> Ghc a
-withCache cache prog = do
-  restoreCache
-  prog <* updateCache
+emptyLoaderStats :: LoaderStats
+emptyLoaderStats =
+  LoaderStats {
+    newBcos = mempty,
+    sameBcos = 0,
+    linker = emptyLinkerStats
+  }
+
+data SymbolsStats =
+  SymbolsStats {
+    new :: Int
+  }
+  deriving stock (Eq, Show)
+
+data NamesStats =
+  NamesStats {
+    new :: Int
+  }
+  deriving stock (Eq, Show)
+
+data StatsUpdate =
+  StatsUpdate {
+    loader :: LoaderStats,
+    symbols :: SymbolsStats,
+    names :: NamesStats
+  }
+  deriving stock (Eq, Show)
+
+emptyStatsUpdate :: StatsUpdate
+emptyStatsUpdate =
+  StatsUpdate {
+    loader = emptyLoaderStats,
+    symbols = SymbolsStats {new = 0},
+    names = NamesStats {new = 0}
+  }
+
+data CacheStats =
+  CacheStats {
+    restore :: StatsUpdate,
+    update :: StatsUpdate
+  }
+  deriving stock (Eq, Show)
+
+emptyStats :: CacheStats
+emptyStats =
+  CacheStats {
+    restore = emptyStatsUpdate,
+    update = emptyStatsUpdate
+  }
+
+data InterpCache =
+  InterpCache {
+    loaderState :: LoaderState,
+    symbols :: SymbolCache
+  }
+
+newtype Target =
+  Target { get :: String }
+  deriving stock (Eq, Show)
+  deriving newtype (Ord)
+
+-- TODO the name cache could in principle be shared directly – try it out
+data Cache =
+  Cache {
+    initialized :: Bool,
+    interp :: Maybe InterpCache,
+    names :: OrigNameCache,
+    stats :: Map Target CacheStats
+  }
+
+emptyCache :: IO (MVar Cache)
+emptyCache =
+  newMVar Cache {
+    initialized = False,
+    interp = Nothing,
+    names = emptyModuleEnv,
+    stats = mempty
+  }
+
+initialize ::
+  MVar Cache ->
+  IO ()
+initialize cache =
+  modifyMVar_ cache \ c -> do
+    unless c.initialized do
+      initUniqSupply 0 1
+    pure c {initialized = True}
+
+basicLinkerStats :: LinkerEnv -> LinkerEnv -> LinkerStats
+basicLinkerStats base update =
+  LinkerStats {
+    newClosures = Set.size (updateClosures \\ baseClosures),
+    newItables = Set.size (updateItables \\ baseItables)
+  }
   where
-    restoreCache =
-      liftIO (readIORef cache) >>= traverse_ \ Cache {interp} ->
-        modifySession \ env -> env {hsc_interp = Just interp}
+    updateClosures = names update.closure_env
+    baseClosures = names base.closure_env
+    updateItables = names update.itbl_env
+    baseItables = names base.itbl_env
 
-    updateCache =
-      withSession \ HscEnv {hsc_interp} ->
-        for_ hsc_interp \ interp ->
-          liftIO $ writeIORef cache (Just Cache {interp})
+    names = Set.fromList . fmap fst . nonDetEltsUFM
+
+basicLoaderStats ::
+  LoaderState ->
+  LoaderState ->
+  LinkerStats ->
+  LoaderStats
+basicLoaderStats base update linker =
+  LoaderStats {
+    newBcos = modStr <$> Set.toList (updateBcos \\ baseBcos),
+    sameBcos = Set.size bcoSame,
+    linker
+  }
+  where
+    modStr = moduleNameString . moduleName
+    bcoSame = Set.intersection updateBcos baseBcos
+    updateBcos = Set.fromList (moduleEnvKeys update.bcos_loaded)
+    baseBcos = Set.fromList (moduleEnvKeys base.bcos_loaded)
+
+basicSymbolsStats :: SymbolCache -> SymbolCache -> SymbolsStats
+basicSymbolsStats base update =
+  SymbolsStats {
+    new = sizeUFM (minusUFM update.get base.get)
+  }
+
+-- TODO complicated
+basicNamesStats :: OrigNameCache -> OrigNameCache -> NamesStats
+basicNamesStats _ _ =
+  NamesStats {
+    new = 0
+  }
+  where
+
+restoreLinkerEnv :: LinkerEnv -> LinkerEnv -> (LinkerEnv, LinkerStats)
+restoreLinkerEnv cached session =
+  (merged, basicLinkerStats session cached)
+  where
+    merged =
+      LinkerEnv {
+        -- UniqFM, <> right-biased
+        closure_env =
+          cached.closure_env
+          <>
+          session.closure_env,
+        -- UniqFM, <> right-biased
+        itbl_env = cached.itbl_env <> session.itbl_env,
+        -- UniqFM, <> right-biased
+        addr_env = cached.addr_env <> session.addr_env
+      }
+
+restoreLoaderState ::
+  LoaderState ->
+  LoaderState ->
+  IO (LoaderState, Maybe LoaderStats)
+restoreLoaderState cached session =
+  pure (merged, Just (basicLoaderStats session cached linkerStats))
+  where
+    merged =
+      LoaderState {
+        linker_env,
+        -- ModuleEnv, left-biased
+        bcos_loaded = plusModuleEnv session.bcos_loaded cached.bcos_loaded,
+        -- ModuleEnv, left-biased
+        objs_loaded = plusModuleEnv session.objs_loaded cached.objs_loaded,
+        -- UniqDFM, depends on the elements in the maps
+        pkgs_loaded = plusUDFM cached.pkgs_loaded session.pkgs_loaded,
+        temp_sos = session.temp_sos
+      }
+
+    (linker_env, linkerStats) = restoreLinkerEnv cached.linker_env session.linker_env
+
+pushStats :: Bool -> Target -> Maybe LoaderStats -> SymbolsStats -> NamesStats -> Cache -> Cache
+pushStats restoring target (Just new) symbols names cache =
+  cache {stats = Map.alter f target cache.stats}
+  where
+    f old = Just (add (fromMaybe emptyStats old))
+    add old | restoring = old {restore = old.restore {loader = new, symbols, names}}
+            | otherwise = old {update = old.update {loader = new, symbols, names}}
+pushStats _ _ _ _ _ cache =
+  cache
+
+restoreCache ::
+  Target ->
+  Maybe LoaderState ->
+  SymbolCache ->
+  OrigNameCache ->
+  Cache ->
+  IO (Cache, (OrigNameCache, (SymbolCache, Maybe LoaderState)))
+restoreCache target initialLoaderState initialSymbolCache initialNames cache
+  | Just InterpCache {..} <- cache.interp
+  = do
+    (restoredLs, loaderStats) <- case initialLoaderState of
+      Just sessionLs ->
+        restoreLoaderState loaderState sessionLs
+      Nothing ->
+        pure (loaderState, Nothing)
+    let
+      newSymbols = initialSymbolCache <> symbols
+      symbolsStats = basicSymbolsStats initialSymbolCache symbols
+      namesStats = basicNamesStats initialNames cache.names
+      newCache = pushStats True target loaderStats symbolsStats namesStats cache
+      -- this overwrites entire modules, since OrigNameCache is a three-level map.
+      -- eventually we'll want to merge properly.
+      names = plusModuleEnv initialNames cache.names
+    pure (newCache, (names, (newSymbols, Just restoredLs)))
+
+  | otherwise
+  = pure (cache, (initialNames, (initialSymbolCache, initialLoaderState)))
+
+-- TODO filter all cached items to include only external Names if possible
+initCache ::
+  LoaderState ->
+  SymbolCache ->
+  OrigNameCache ->
+  Cache ->
+  IO Cache
+initCache loaderState symbols names Cache {names = _, ..} =
+  pure Cache {interp = Just InterpCache {..}, ..}
+
+updateLinkerEnv :: LinkerEnv -> LinkerEnv -> (LinkerEnv, LinkerStats)
+updateLinkerEnv cached session =
+  (merged, basicLinkerStats cached session)
+  where
+    merged =
+      LinkerEnv {
+        -- UniqFM, <> right-biased
+        closure_env =
+          cached.closure_env
+          <>
+          session.closure_env,
+        -- UniqFM, <> right-biased
+        itbl_env = cached.itbl_env <> session.itbl_env,
+        -- UniqFM, <> right-biased
+        addr_env = cached.addr_env <> session.addr_env
+      }
+
+updateLoaderState ::
+  LoaderState ->
+  LoaderState ->
+  IO (LoaderState, Maybe LoaderStats)
+updateLoaderState cached session = do
+  pure (merged, Just stats {linker = linkerStats})
+  where
+    merged =
+      LoaderState {
+        linker_env,
+        -- ModuleEnv, left-biased
+        bcos_loaded = plusModuleEnv session.bcos_loaded cached.bcos_loaded,
+        -- ModuleEnv, left-biased
+        objs_loaded = plusModuleEnv session.objs_loaded cached.objs_loaded,
+        -- UniqDFM, depends on the elements in the maps
+        pkgs_loaded = plusUDFM cached.pkgs_loaded session.pkgs_loaded,
+        temp_sos = session.temp_sos
+      }
+
+    (linker_env, linkerStats) = updateLinkerEnv cached.linker_env session.linker_env
+
+    stats = basicLoaderStats cached session emptyLinkerStats
+
+updateCache ::
+  Target ->
+  InterpCache ->
+  LoaderState ->
+  SymbolCache ->
+  OrigNameCache ->
+  Cache ->
+  IO Cache
+updateCache target InterpCache {..} newLoaderState newSymbols newNames cache = do
+  (updatedLs, stats) <- updateLoaderState loaderState newLoaderState
+  pure $ pushStats False target stats symbolsStats namesStats cache {
+    interp = Just InterpCache {
+      loaderState = updatedLs,
+      symbols = symbols <> newSymbols
+    },
+    -- for now: when a module is compiled, its names are definitely complete, so when a downstream module uses it as a
+    -- dep, we don't want to overwrite the previous entry.
+    -- but when we recompile parts of the tree this is different, so wel'll want to merge properly.
+    names = plusModuleEnv newNames cache.names
+  }
+  where
+    symbolsStats = basicSymbolsStats symbols newSymbols
+    namesStats = basicNamesStats cache.names newNames
+
+report ::
+  MonadIO m =>
+  MVar Log ->
+  MVar Cache ->
+  Target ->
+  m ()
+report logVar cacheVar target =
+  liftIO (readMVar cacheVar) >>= \ Cache {stats} ->
+    for_ (Map.lookup target stats) \ CacheStats {restore, update} -> do
+      let
+        restoreStats =
+          text (show (length restore.loader.newBcos)) <+> text "BCOs" $$
+          text (show restore.loader.linker.newClosures) <+> text "closures" $$
+          text (show restore.symbols.new) <+> text "symbols" $$
+          text (show restore.loader.sameBcos) <+> text "BCOs already in cache"
+
+        newBcos = text <$> update.loader.newBcos
+
+        updateStats =
+          (if null newBcos then text "No new BCOs" else text "New BCOs:" <+> fsep (punctuate comma newBcos)) $$
+          text (show update.loader.linker.newClosures) <+> text "new closures" $$
+          text (show update.symbols.new) <+> text "new symbols" $$
+          text (show update.loader.sameBcos) <+> text "BCOs already in cache"
+
+      logd logVar $ hang (text target.get Outputable.<> text ":") 2 $
+        hang (text "Restore:") 2 restoreStats $$
+        hang (text "Update:") 2 updateStats
+
+withCache :: MVar Log -> MVar Cache -> [String] -> Ghc a -> Ghc a
+withCache logVar cacheVar [src] prog = do
+  liftIO (initialize cacheVar)
+  -- If we don't initialize the loader here, it will happen at some later point.
+  -- When our restored cache is in the loader state then, it will be corrupted.
+  withSession \ hsc_env -> liftIO $ for_ hsc_env.hsc_interp (flip initLoaderState hsc_env)
+  prepare
+  finally (prog <* finalize) (report logVar cacheVar target)
+  where
+    prepare =
+      withSession \ HscEnv {hsc_interp, hsc_NC = NameCache {nsNames}} -> for_ hsc_interp \ Interp {..} ->
+        liftIO $ modifyMVar_ interpLoader.loader_state \ initialLoaderState ->
+          modifyMVar interpLookupSymbolCache \ initialSymbolCache ->
+            (first coerce) <$>
+            modifyMVar nsNames \ names ->
+              modifyMVar cacheVar (restoreCache target initialLoaderState (SymbolCache initialSymbolCache) names)
+
+    finalize =
+      withSession \ HscEnv {hsc_interp, hsc_NC = NameCache {nsNames}} ->
+        for_ hsc_interp \ Interp {interpLoader = Loader {loader_state}, interpLookupSymbolCache} ->
+          liftIO $ readMVar loader_state >>= traverse_ \ newLoaderState -> do
+            newSymbols <- readMVar interpLookupSymbolCache
+            newNames <- readMVar nsNames
+            modifyMVar_ cacheVar \ c ->
+              maybe initCache (updateCache target) c.interp newLoaderState (SymbolCache newSymbols) newNames c
+
+    target = Target src
+
+withCache logVar _ _ prog = do
+  liftIO $ logOther logVar "withCache called with target count /= 1"
+  prog

--- a/buck-worker/Error.hs
+++ b/buck-worker/Error.hs
@@ -2,19 +2,19 @@
 
 module Error where
 
+import Control.Concurrent.MVar (MVar)
 import Control.Exception (AsyncException (..), Exception (..), IOException, throwIO)
 import qualified Control.Monad.Catch as MC
 import Control.Monad.IO.Class (liftIO)
 import GHC (Ghc, GhcException (..), printException)
-import GHC.Driver.Session (FlushOut (..), defaultFatalMessager, defaultFlushOut)
 import GHC.Types.SourceError (SourceError)
+import Log (Log, logOther)
 import System.Environment (getProgName)
 import System.Exit (ExitCode)
 
-handleExceptions :: a -> Ghc a -> Ghc a
-handleExceptions errResult =
+handleExceptions :: MVar Log -> a -> Ghc a -> Ghc a
+handleExceptions logVar errResult =
   MC.handle \ e -> do
-    liftIO flushOut
     handler e
     pure errResult
   where
@@ -46,5 +46,4 @@ handleExceptions errResult =
       | otherwise
       = fm (show (Panic (show exception)))
 
-    fm = liftIO . defaultFatalMessager
-    FlushOut flushOut = defaultFlushOut
+    fm = logOther logVar

--- a/buck-worker/Main.hs
+++ b/buck-worker/Main.hs
@@ -3,7 +3,7 @@
 module Main where
 
 import Args (parseBuckArgs, writeResult)
-import Cache (Cache, emptyCache)
+import Cache (Cache (..), emptyCache)
 import Compile (compile)
 import Control.Concurrent.MVar (MVar, newMVar, readMVar)
 import Control.Exception (SomeException (SomeException), throwIO, try)
@@ -79,7 +79,7 @@ main = do
   hSetBuffering stderr LineBuffering
   socket <- lookupEnv "WORKER_SOCKET"
   hPutStrLn stderr $ "using worker socket: " <> show socket
-  cache <- emptyCache
+  cache <- emptyCache True
   workerServer (handlers cache) (maybe id setSocket socket defaultServiceOptions)
   where
     setSocket s options = options {serverHost = fromString ("unix://" <> s <> "\x00"), serverPort = 0}

--- a/buck-worker/Main.hs
+++ b/buck-worker/Main.hs
@@ -1,14 +1,12 @@
-{-# language DataKinds, OverloadedLists, OverloadedStrings, GADTs #-}
+{-# language DataKinds, OverloadedLists, OverloadedStrings, GADTs, OverloadedRecordDot #-}
 
 module Main where
 
 import Args (parseBuckArgs, writeResult)
-import Cache (CacheRef)
+import Cache (Cache, emptyCache)
 import Compile (compile)
-import Control.Concurrent.MVar (newMVar, readMVar)
-import Control.Exception (throwIO)
-import Data.Foldable (traverse_)
-import Data.IORef (newIORef)
+import Control.Concurrent.MVar (MVar, newMVar, readMVar)
+import Control.Exception (SomeException (SomeException), throwIO, try)
 import Data.String (fromString)
 import qualified Data.Text as Text
 import Data.Text.Encoding (decodeUtf8Lenient)
@@ -30,24 +28,35 @@ import System.IO (BufferMode (LineBuffering), hPutStrLn, hSetBuffering, stderr, 
 import Worker (ExecuteCommand (..), ExecuteEvent (..), ExecuteResponse (..), Worker (..), workerServer)
 
 executeHandler ::
-  CacheRef ->
+  MVar Cache ->
   ServerRequest 'Normal ExecuteCommand ExecuteResponse ->
   IO (ServerResponse 'Normal ExecuteResponse)
 executeHandler cache (ServerNormalRequest _ ExecuteCommand {executeCommandArgv}) = do
-  hPutStrLn stderr (unlines argv)
-  args <- either (throwIO . userError) pure (parseBuckArgs argv)
-  log <- newMVar Log {diagnostics = [], other = []}
-  result <- withGhc Env {log, cache, args} (compile args)
-  executeResponseExitCode <- writeResult args result
-  Log {diagnostics, other} <- readMVar log
-  traverse_ (hPutStrLn stderr) (reverse other)
-  let
-    response = ExecuteResponse {
-      executeResponseExitCode,
-      executeResponseStderr = mconcat (LazyText.pack <$> reverse diagnostics)
-      }
+  -- hPutStrLn stderr (unlines argv)
+  response <- either exceptionResponse successResponse =<< try run
   pure (ServerNormalResponse response [] StatusOk "")
   where
+    run = do
+      args <- either (throwIO . userError) pure (parseBuckArgs argv)
+      log <- newMVar Log {diagnostics = [], other = []}
+      let env = Env {log, cache, args}
+      result <- withGhc env (compile args)
+      pure (env, result)
+
+    successResponse (env, result) = do
+      executeResponseExitCode <- writeResult env.args result
+      Log {diagnostics, other} <- readMVar env.log
+      pure ExecuteResponse {
+        executeResponseExitCode,
+        executeResponseStderr = LazyText.unlines (LazyText.pack <$> reverse (other ++ diagnostics))
+      }
+
+    exceptionResponse (SomeException e) =
+      pure ExecuteResponse {
+        executeResponseExitCode = 1,
+        executeResponseStderr = "Uncaught exception: " <> LazyText.pack (show e)
+      }
+
     argv = Text.unpack . decodeUtf8Lenient <$> Vector.toList executeCommandArgv
 
 execHandler ::
@@ -57,7 +66,7 @@ execHandler (ServerReaderRequest _metadata _recv) = do
   hPutStrLn stderr "Received Exec"
   error "not implemented"
 
-handlers :: CacheRef -> Worker ServerRequest ServerResponse
+handlers :: MVar Cache -> Worker ServerRequest ServerResponse
 handlers cache =
   Worker
     { workerExecute = executeHandler cache,
@@ -70,7 +79,7 @@ main = do
   hSetBuffering stderr LineBuffering
   socket <- lookupEnv "WORKER_SOCKET"
   hPutStrLn stderr $ "using worker socket: " <> show socket
-  cache <- newIORef Nothing
+  cache <- emptyCache
   workerServer (handlers cache) (maybe id setSocket socket defaultServiceOptions)
   where
     setSocket s options = options {serverHost = fromString ("unix://" <> s <> "\x00"), serverPort = 0}

--- a/buck-worker/Main.hs
+++ b/buck-worker/Main.hs
@@ -38,7 +38,7 @@ executeHandler cache (ServerNormalRequest _ ExecuteCommand {executeCommandArgv})
   where
     run = do
       args <- either (throwIO . userError) pure (parseBuckArgs argv)
-      log <- newMVar Log {diagnostics = [], other = []}
+      log <- newMVar Log {diagnostics = [], other = [], debug = False}
       let env = Env {log, cache, args}
       result <- withGhc env (compile args)
       pure (env, result)

--- a/buck-worker/Session.hs
+++ b/buck-worker/Session.hs
@@ -87,7 +87,7 @@ parseFlags argv = do
   logger1 <- getLogger
   let logger2 = setLogFlags logger1 (initLogFlags dflags1)
   (dflags, fileish_args, dynamicFlagWarnings) <- parseDynamicFlags logger2 dflags1 argv
-  pure (dflags {verbosity = 0}, setLogFlags logger2 (initLogFlags dflags), fileish_args, dynamicFlagWarnings)
+  pure (dflags, setLogFlags logger2 (initLogFlags dflags), fileish_args, dynamicFlagWarnings)
 
 initGhc ::
   DynFlags ->

--- a/buck-worker/Session.hs
+++ b/buck-worker/Session.hs
@@ -42,7 +42,7 @@ runSession Env {log, args} prog = do
   topdir <- readPath args.ghcDirFile
   packageDb <- readPath args.ghcDbFile
   let packageDbArg path = ["-package-db", path]
-      argv = args.ghcOptions ++ foldMap packageDbArg packageDb
+      argv = args.ghcOptions ++ foldMap packageDbArg packageDb ++ foldMap packageDbArg args.buck2PackageDb
   runGhc topdir do
     handleExceptions log Nothing (prog (map loc argv))
   where

--- a/buck-worker/cabal.project
+++ b/buck-worker/cabal.project
@@ -37,6 +37,6 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/tek/proto3-suite
-  tag: 656e0f8cabe71ac318f4278e455ddc4888dd7502
+  tag: 630e141045050cc88051057aa00006fb874ffe70
 
 index-state: 2024-09-19T00:00:00Z

--- a/buck-worker/worker.cabal
+++ b/buck-worker/worker.cabal
@@ -15,3 +15,11 @@ executable worker-demo
     , unix
     , grpc-haskell
   default-language: GHC2021
+  default-extensions:
+    BlockArguments,
+    DerivingStrategies,
+    RecordWildCards,
+    DuplicateRecordFields,
+    OverloadedRecordDot,
+    StrictData,
+    NoFieldSelectors


### PR DESCRIPTION
These changes increase the granularity of the data stored in the shared cache, with slightly different update rules for
each of them. So far this has only been tested very superficially, so it will break in many nontrivial contexts.

To observe this mechanism a bit, this also adds a skeleton for recording some statistics about a compile job's
interactions with our shared cache, like how many of the BCO sets in the loader state at the end of the session have
been added freshly.

Otherwise, this includes a few tweaks to properly handle the Buck2 environment, like the CLI options `--bin-path` and
`--buck2-package-db`, and environment variables included in RPC messages.
